### PR TITLE
fix typo to the workflow notebook file

### DIFF
--- a/tutorial/_toc.yml
+++ b/tutorial/_toc.yml
@@ -39,7 +39,7 @@ parts:
   - file: part3/data_exploitability_pangeo
     title: How to exploit data on Pangeo
   - file: part3/chunking_introduction
-    title: Data and pre-processing general knowledge
+    title: Data and preprocessing general knowledge
   - file: part3/scaling_dask
     title: Scaling with Dask
   - file: part3/scaling_openEO
@@ -48,7 +48,7 @@ parts:
     title: Advanced OpenEO (UDF)
   - file: part3/advanced_ufunc
     title: Advanced OpenEO (Ufunc)
-  - file: part3/advanced_worflow
+  - file: part3/advanced_workflow
     title: Advanced OpenEO (Workflow)
 
 - caption: Beyond the workshop


### PR DESCRIPTION
The PR fixes a typo in the filename of the workflow notebook.